### PR TITLE
Fixed readme typo (maybe?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ const app = authorizer({
   providers: { ... },
   subjects,
   async success(ctx, value) { ... },
-  storage: new MemoryStore(),
+  storage: MemoryStorage(),
 })
 ```
 


### PR DESCRIPTION
I was trying out openauthjs based on the README, and noticed a typo on the memory storage example. 

Also apparently `MemoryStorage` is not a class? It looks like you have to create it without the `new` keyword. 