### PR TITLE
fix: correct redirect url if its from cloudfront

### DIFF
--- a/.changeset/rare-mails-flow.md
+++ b/.changeset/rare-mails-flow.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+fix for password adapter not redirecting to the right place after change password flow

--- a/packages/openauth/src/adapter/password.ts
+++ b/packages/openauth/src/adapter/password.ts
@@ -214,12 +214,7 @@ export function PasswordAdapter(config: PasswordConfig) {
 
       routes.get("/change", async (c) => {
         let redirect =
-          c.req.query("redirect_uri") ||
-          c.req.url.replace(/change.*/, "authorize")
-        const fowardedHost = c.req.header("x-forwarded-host")
-        if (redirect.includes(".lambda-url.") && fowardedHost) {
-          redirect = `https://${fowardedHost}/password/authorize`
-        }
+          c.req.query("redirect_uri") || getRelativeUrl(c, "./authorize")
         const state: PasswordChangeState = {
           type: "start",
           redirect,
@@ -372,6 +367,7 @@ export function PBKDF2Hasher(opts?: { interations?: number }): PasswordHasher<{
   }
 }
 import { timingSafeEqual, randomBytes, scrypt } from "node:crypto"
+import { getRelativeUrl } from "../util.js"
 
 export function ScryptHasher(opts?: {
   N?: number

--- a/packages/openauth/src/adapter/password.ts
+++ b/packages/openauth/src/adapter/password.ts
@@ -213,9 +213,13 @@ export function PasswordAdapter(config: PasswordConfig) {
       })
 
       routes.get("/change", async (c) => {
-        const redirect =
+        let redirect =
           c.req.query("redirect_uri") ||
           c.req.url.replace(/change.*/, "authorize")
+        const fowardedHost = c.req.header("x-forwarded-host")
+        if (redirect.includes(".lambda-url.") && fowardedHost) {
+          redirect = `https://${fowardedHost}/password/authorize`
+        }
         const state: PasswordChangeState = {
           type: "start",
           redirect,


### PR DESCRIPTION
Not sure if this is the best way to go about this, but this fixes #91 

The issue was the `/change` route would use the lambda url instead of the cloudfront url when going through the `forgot` password flow. 