### PR TITLE
fix: add `node:` prefix for built-in modules

### DIFF
--- a/.changeset/young-insects-repeat.md
+++ b/.changeset/young-insects-repeat.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+fix: add `node:` prefix for built-in modules

--- a/packages/openauth/src/adapter/password.ts
+++ b/packages/openauth/src/adapter/password.ts
@@ -304,7 +304,7 @@ export function PasswordAdapter(config: PasswordConfig) {
 }
 
 import * as jose from "jose"
-import { TextEncoder } from "util"
+import { TextEncoder } from "node:util"
 
 interface HashedPassword {}
 
@@ -367,7 +367,7 @@ export function PBKDF2Hasher(opts?: { interations?: number }): PasswordHasher<{
     },
   }
 }
-import { timingSafeEqual, randomBytes, scrypt } from "crypto"
+import { timingSafeEqual, randomBytes, scrypt } from "node:crypto"
 
 export function ScryptHasher(opts?: {
   N?: number

--- a/packages/openauth/src/random.ts
+++ b/packages/openauth/src/random.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "crypto"
+import { timingSafeEqual } from "node:crypto"
 
 export function generateUnbiasedDigits(length: number): string {
   const result: number[] = []

--- a/packages/openauth/src/storage/memory.ts
+++ b/packages/openauth/src/storage/memory.ts
@@ -1,6 +1,6 @@
 import { joinKey, splitKey, StorageAdapter } from "./storage.js"
-import { existsSync, readFileSync } from "fs"
-import { writeFile } from "fs/promises"
+import { existsSync, readFileSync } from "node:fs"
+import { writeFile } from "node:fs/promises"
 
 export interface MemoryStorageOptions {
   persist?: string


### PR DESCRIPTION
```
> wrangler dev

Proxy environment variables detected. We'll use your proxy for fetch requests.

 ⛅️ wrangler 3.99.0
-------------------

X [ERROR] Build failed with 5 errors:

  X [ERROR] Could not resolve "util"
  

  node_modules/.pnpm/@openauthjs+openauth@0.2.5_arctic@2.3.3_hono@4.6.14/node_modules/@openauthjs/openauth/dist/esm/adapter/password.js:6:28:
        6 │ import { TextEncoder } from "util";
          ╵                             ~~~~~~

    The package "util" wasn't found on the file system but is built into node.
    - Make sure to prefix the module name with "node:" or update your compatibility_date to
  2024-09-23 or later.



  X [ERROR] Could not resolve "crypto"


  node_modules/.pnpm/@openauthjs+openauth@0.2.5_arctic@2.3.3_hono@4.6.14/node_modules/@openauthjs/openauth/dist/esm/adapter/password.js:7:53:
        7 │ import { timingSafeEqual, randomBytes, scrypt } from "crypto";
          ╵                                                      ~~~~~~~~

    The package "crypto" wasn't found on the file system but is built into node.
    - Make sure to prefix the module name with "node:" or update your compatibility_date to
  2024-09-23 or later.



  X [ERROR] Could not resolve "crypto"


  node_modules/.pnpm/@openauthjs+openauth@0.2.5_arctic@2.3.3_hono@4.6.14/node_modules/@openauthjs/openauth/dist/esm/random.js:2:32:
        2 │ import { timingSafeEqual } from "crypto";
          ╵                                 ~~~~~~~~

    The package "crypto" wasn't found on the file system but is built into node.
    - Make sure to prefix the module name with "node:" or update your compatibility_date to
  2024-09-23 or later.



  X [ERROR] Could not resolve "fs"


  node_modules/.pnpm/@openauthjs+openauth@0.2.5_arctic@2.3.3_hono@4.6.14/node_modules/@openauthjs/openauth/dist/esm/storage/memory.js:3:41:
        3 │ import { existsSync, readFileSync } from "fs";
          ╵                                          ~~~~

    The package "fs" wasn't found on the file system but is built into node.
    - Make sure to prefix the module name with "node:" or update your compatibility_date to
  2024-09-23 or later.



  X [ERROR] Could not resolve "fs/promises"


  node_modules/.pnpm/@openauthjs+openauth@0.2.5_arctic@2.3.3_hono@4.6.14/node_modules/@openauthjs/openauth/dist/esm/storage/memory.js:4:26:
        4 │ import { writeFile } from "fs/promises";
          ╵                           ~~~~~~~~~~~~~

    The package "fs/promises" wasn't found on the file system but is built into node.
    - Make sure to prefix the module name with "node:" or update your compatibility_date to
  2024-09-23 or later.
```