### PR TITLE
Allow phone auth via CodeUI

### DIFF
--- a/.changeset/gorgeous-jeans-sniff.md
+++ b/.changeset/gorgeous-jeans-sniff.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+ui: support phone mode for code ui

--- a/packages/openauth/src/ui/code.tsx
+++ b/packages/openauth/src/ui/code.tsx
@@ -60,13 +60,6 @@ export function CodeUI(props: {
                 pattern={inputPattern ?? undefined}
                 title={inputTitle ?? undefined}
                 inputmode={inputType === "tel" ? "numeric" : "email"}
-                autocomplete={
-                  inputType === "email"
-                    ? "email"
-                    : inputType === "tel"
-                      ? "tel"
-                      : "off"
-                }
                 required
                 placeholder={copy.email_placeholder}
               />
@@ -107,6 +100,8 @@ export function CodeUI(props: {
                 type="text"
                 name="code"
                 required
+                inputmode="numeric"
+                autocomplete="one-time-code"
                 placeholder={copy.code_placeholder}
               />
               <button data-component="button">{copy.button_continue}</button>

--- a/packages/openauth/src/ui/code.tsx
+++ b/packages/openauth/src/ui/code.tsx
@@ -20,14 +20,25 @@ const DEFAULT_COPY = {
 
 export type CodeUICopy = typeof DEFAULT_COPY
 
+export type CodeUIInputOptions = Partial<{
+  inputType: "email" | "text" | "tel"
+  inputName: string
+  inputPattern: string
+  inputTitle: string
+}>
+
 export function CodeUI(props: {
   sendCode: (claims: Record<string, string>, code: string) => Promise<void>
   copy?: Partial<CodeUICopy>
+  inputOptions?: CodeUIInputOptions
 }) {
   const copy = {
     ...DEFAULT_COPY,
     ...props.copy,
   }
+
+  const { inputName, inputPattern, inputTitle, inputType } =
+    props.inputOptions ?? {}
 
   return {
     sendCode: props.sendCode,
@@ -44,8 +55,18 @@ export function CodeUI(props: {
               <input
                 data-component="input"
                 autofocus
-                type="email"
-                name="email"
+                type={inputType ?? "email"}
+                name={inputName ?? "email"}
+                pattern={inputPattern ?? undefined}
+                title={inputTitle ?? undefined}
+                inputmode={inputType === "tel" ? "numeric" : "email"}
+                autocomplete={
+                  inputType === "email"
+                    ? "email"
+                    : inputType === "tel"
+                      ? "tel"
+                      : "off"
+                }
                 required
                 placeholder={copy.email_placeholder}
               />

--- a/packages/openauth/src/ui/code.tsx
+++ b/packages/openauth/src/ui/code.tsx
@@ -20,25 +20,17 @@ const DEFAULT_COPY = {
 
 export type CodeUICopy = typeof DEFAULT_COPY
 
-export type CodeUIInputOptions = Partial<{
-  inputType: "email" | "text" | "tel"
-  inputName: string
-  inputPattern: string
-  inputTitle: string
-}>
-
 export function CodeUI(props: {
   sendCode: (claims: Record<string, string>, code: string) => Promise<void>
   copy?: Partial<CodeUICopy>
-  inputOptions?: CodeUIInputOptions
+  mode?: "email" | "phone"
 }) {
   const copy = {
     ...DEFAULT_COPY,
     ...props.copy,
   }
 
-  const { inputName, inputPattern, inputTitle, inputType } =
-    props.inputOptions ?? {}
+  const mode = props.mode ?? "email"
 
   return {
     sendCode: props.sendCode,
@@ -55,11 +47,9 @@ export function CodeUI(props: {
               <input
                 data-component="input"
                 autofocus
-                type={inputType ?? "email"}
-                name={inputName ?? "email"}
-                pattern={inputPattern ?? undefined}
-                title={inputTitle ?? undefined}
-                inputmode={inputType === "tel" ? "numeric" : "email"}
+                type={mode === "email" ? "email" : "tel"}
+                name={mode === "email" ? "email" : "phone"}
+                inputmode={mode === "email" ? "email" : "numeric"}
                 required
                 placeholder={copy.email_placeholder}
               />


### PR DESCRIPTION
Current Code UI allows for only email based auth 
```
<input
  data-component="input"
  autofocus
  type="email"
  name="email"
  required
  placeholder={copy.email_placeholder}
/>
```
With slight modification it can used to allow phone based auth as well. 
```tsx
<input
  data-component="input"
  autofocus
  type={props.inputOptions?.inputType ?? "email"}
  name={props.inputOptions?.inputName ?? "email"}
  pattern={props.inputOptions?.inputPattern ?? undefined}
  title={props.inputOptions?.inputTitle ?? undefined}
  required
  placeholder={copy.email_placeholder}
/>
```
Have added two additional attributes `pattern` and `title` in-order to allow input validation based on custom requirements.

inputType can be tel, text or email

Also added `inputmode` and `autocomplete` to autoread OTP/code in mobile browsers 
              