### PR TITLE
feat: Add SAML support (browser-post)

### DIFF
--- a/packages/openauth/package.json
+++ b/packages/openauth/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "@standard-schema/spec": "1.0.0-beta.3",
     "aws4fetch": "1.0.20",
-    "jose": "5.9.6"
+    "jose": "5.9.6",
+    "@node-saml/node-saml": "5.0.0"
   },
   "files": [
     "src",

--- a/packages/openauth/src/adapter/saml.ts
+++ b/packages/openauth/src/adapter/saml.ts
@@ -1,0 +1,101 @@
+import { SAML } from "@node-saml/node-saml"
+import { Adapter } from "./adapter.js"
+import { getRelativeUrl } from "../util.js"
+import { Context } from "hono"
+import { InvalidSubjectError } from "../error.js"
+
+export interface SamlConfig {
+  type?: string
+  idpCert: string | string[];
+  idpIssuer: string;
+  idpSignonUrl: string;
+}
+
+export interface SamlClaims {
+  nameID: string
+  attributes?: Record<string, string[]>,
+}
+
+interface AdapterState {
+  relayState: string
+}
+
+export function SamlAdapter(
+  config: SamlConfig,
+): Adapter<{ claims: SamlClaims}> {
+  return {
+    type: config.type || "saml",
+    init(routes, ctx) {
+      routes.get("/authorize", async (c) => {
+        const saml = getSaml(c, config)
+        const relayState = crypto.randomUUID()
+        await ctx.set<AdapterState>(c, "adapter", 60 * 10, {
+          relayState,
+        })
+        const form = await saml.getAuthorizeFormAsync(relayState)
+        return c.html(form);
+      })
+
+      routes.post("/callback", async (c) => {
+        const saml = getSaml(c, config)
+        const adapter = (await ctx.get(c, "adapter")) as AdapterState
+        const formData = await c.req.formData();
+        
+        const relayState = formData.get('RelayState')
+        if (!adapter || (adapter.relayState && relayState !== adapter.relayState)) {
+          return c.redirect(getRelativeUrl(c, "./authorize"))
+        }
+
+        const samlResponse = formData.get('SAMLResponse')
+        if(samlResponse) {
+          const p = await saml.validatePostResponseAsync({
+            SAMLResponse: samlResponse.toString(),
+            RelayState: relayState ? relayState.toString() : "",
+          })
+
+          if(!p.profile) {
+            throw new InvalidSubjectError();
+          }
+
+          return ctx.success(c, {
+            claims: {
+              get nameID() {
+                return p.profile?.nameID || ""
+              },
+              get attributes() {
+                const attributes = <Record<string, string[]>> {};
+                if(p.profile && p.profile["attributes"]) {
+                  for(const attr of Object.entries(p.profile["attributes"])) {
+                    const key = attr[0]
+                    const val = attr[1]
+                    if(typeof val === 'string') {
+                      attributes[key] = [val]
+                    }
+                    if(isNonEmptyArrayOfStrings(val)) {
+                      attributes[key] = val
+                    }
+                  }
+                  return attributes;
+                }
+              }
+            },
+          })
+        }
+      })
+    },
+  }
+}
+
+const isNonEmptyArrayOfStrings = (value: unknown): value is string[] => {
+  return Array.isArray(value) && value.length > 0 && value.every(item => typeof item === "string");
+}
+
+const getSaml = (c: Context, config: SamlConfig) => {
+  return new SAML({ 
+    idpCert: config.idpCert,
+    issuer: config.idpIssuer,
+    entryPoint: config.idpSignonUrl,
+    audience: getRelativeUrl(c, "./authorize"),
+    callbackUrl: getRelativeUrl(c, "."),
+   })
+}


### PR DESCRIPTION
Add basic browser-post SAML support using @node-saml/node-saml.

Tested via a modified `authorizer.ts` using Okta, as below.
```
import { authorizer } from "@openauthjs/openauth"
import { MemoryStorage } from "@openauthjs/openauth/storage/memory"
import { subjects } from "../../subjects.js"
import { SamlAdapter } from "@openauthjs/openauth/adapter/saml"

async function getUser(nameID: string) {
  // Get user from database
  // Return user ID
  return nameID
}

export default authorizer({
  subjects,
  storage: MemoryStorage({
    persist: "./persist.json",
  }),
  providers: {
    saml: SamlAdapter({
      idpCert: 'MIIDpjCCAo6gAwIBAgIGAZPxVe/7MA0GCSqGSIb3DQEBCwUAMIGTMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNjbzENMAsGA1UECgwET2t0YTEUMBIGA1UECwwLU1NPUHJvdmlkZXIxFDASBgNVBAMMC2Rldi03NjgzMzc5MRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9rdGEuY29tMB4XDTI0MTIyMzAyMjUwMVoXDTM0MTIyMzAyMjYwMVowgZMxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRYwFAYDVQQHDA1TYW4gRnJhbmNpc2NvMQ0wCwYDVQQKDARPa3RhMRQwEgYDVQQLDAtTU09Qcm92aWRlcjEUMBIGA1UEAwwLZGV2LTc2ODMzNzkxHDAaBgkqhkiG9w0BCQEWDWluZm9Ab2t0YS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCkeCKYAi+Fhjw/8XXfPrLmFQGkAG43AD5L57ODvdQozYai1hCTxIc/m+9TiuaeS+Ujq9DuSqfdg5JypZ+tmk4btFyj8NwHUV1gUgnY/yHIzGxGwuMGlb5PlVASN4pCvOSsEApjolGOnHV0OyKmGJPB8HlIarEYC9oKh2TByq8O+fJbaTs0ifWlg1xTE8emPhE/QQKzSZKccwaZC5eo/0R+tt7J5r4qCjki1wtPRYDQPh7mNoJ+EjBtnPEAJiHvA5Jn1K0EuHf07OC3in91j0boPzh1vlgXI3//P/BVDkTUuyindFh/gdkhVEDXISI9yqqGrWJ8kSHOUdoEYBvbFTORAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAGPVYctYWJTM7tkvjdDo9S2KAOMcEG4O+elz2IuXXnkjQiLLQx98HUm6PT35EEr/3rNpMviHRjC2s5V4P3I9/LKg3VyNVli8KoFjFX5166PqL2cJpfo8vwe3WYwY9skWqvrYvaPUiQrio6g+TsVpsUkIj3wwAJHGFgQnTykHSMi4lWgWNIIrWGfd9fivqFhbc7F41wt/zr+hB32Nl1EYNb51dlQhVLB4lVm4JQXkzJ7VJeJkk46E72noiU6tyIN0HKVoEvERm+nmZOLbjvRuR7GprE4/JiDJI76rgUjOTPFz77ZvfiONw0gwHlmDalgusm+DTXoqqsNSQIMYR2WMeXs=',
      idpIssuer: 'http://www.okta.com/exkm2znudk4iKZc3u5d7',
      idpSignonUrl: 'https://dev-7683379.okta.com/app/dev-7683379_openauthjs_1/exkm2znudk4iKZc3u5d7/sso/saml'
    }) 
  },
  success: async (ctx, value) => {
    if (value.provider === "saml") {
      return ctx.subject("user", {
        id: await getUser(value.claims.nameID),
      })
    }
    throw new Error("Invalid provider")
  },
})
```