### PR TITLE
Import only hono type in util.ts

### DIFF
--- a/.changeset/mighty-tips-shout.md
+++ b/.changeset/mighty-tips-shout.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+Import only hono type in util.ts

--- a/packages/openauth/src/util.ts
+++ b/packages/openauth/src/util.ts
@@ -1,4 +1,4 @@
-import { Context } from "hono"
+import type { Context } from "hono"
 
 export type Prettify<T> = {
   [K in keyof T]: T[K]


### PR DESCRIPTION
util.ts is used by openauth client as well, so lets not import hono when we do not need it