### PR TITLE
feat: Bitbucket Adapter

### DIFF
--- a/.changeset/warm-snakes-film.md
+++ b/.changeset/warm-snakes-film.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+Feat: Added Bitbucket Adapter

--- a/packages/openauth/src/adapter/bitbucket.ts
+++ b/packages/openauth/src/adapter/bitbucket.ts
@@ -1,0 +1,87 @@
+import { Oauth2Adapter, Oauth2WrappedConfig } from "./oauth2.js"
+
+/**
+ * Represents the various scopes that can be used for Bitbucket API access.
+ * 
+ * A descriptor lacking the scopes element is implicitly assumed to require all scopes and as a result, Bitbucket will require end users authorizing/installing the add-on to explicitly accept all scopes.
+ * 
+ * - `project`: Read access to projects.
+ * - `project:write`: Write access to projects.
+ * - `project:admin`: Admin access to projects.
+ * - `repository`: Read access to repositories.
+ * - `repository:write`: Write access to repositories.
+ * - `repository:admin`: Admin access to repositories.
+ * - `repository:delete`: Delete access to repositories.
+ * - `pullrequest`: Read access to pull requests.
+ * - `pullrequest:write`: Write access to pull requests.
+ * - `issue`: Read access to issues.
+ * - `issue:write`: Write access to issues.
+ * - `wiki`: Access to wikis.
+ * - `webhook`: Access to webhooks.
+ * - `snippet`: Read access to snippets.
+ * - `snippet:write`: Write access to snippets.
+ * - `email`: Access to email addresses.
+ * - `account`: Read access to account information.
+ * - `account:write`: Write access to account information.
+ * - `pipeline`: Read access to pipelines.
+ * - `pipeline:write`: Write access to pipelines.
+ * - `pipeline:variable`: Access to pipeline variables.
+ * - `runner`: Read access to runners.
+ * - `runner:write`: Write access to runners.
+ * 
+ * @see {@link https://developer.atlassian.com/cloud/bitbucket/rest/intro/#authentication}
+ */
+type Scope = 
+    | "project"
+    | "project:write"
+    | "project:admin"
+    | "repository"
+    | "repository:write"
+    | "repository:admin"
+    | "repository:delete"
+    | "pullrequest"
+    | "pullrequest:write"
+    | "issue"
+    | "issue:write"
+    | "wiki"
+    | "webhook"
+    | "snippet"
+    | "snippet:write"
+    | "email"
+    | "account"
+    | "account:write"
+    | "pipeline"
+    | "pipeline:write"
+    | "pipeline:variable"
+    | "runner"
+    | "runner:write"
+
+/**
+ * Configuration interface for Bitbucket OAuth2 integration.
+ * 
+ * @extends Oauth2WrappedConfig
+ * 
+ * @property {Scope[]} scopes - An array of scopes that specify the permissions requested from the user.
+ */
+export interface BitbucketConfig extends Oauth2WrappedConfig {
+    scopes: Scope[]
+}
+
+/**
+ * Creates an OAuth2 adapter configured for Bitbucket.
+ *
+ * This function configures an OAuth2 adapter specifically for Bitbucket by
+ * providing the necessary authorization and token endpoints.
+ * 
+ * @see {@link https://developer.atlassian.com/cloud/bitbucket/rest/intro/#authentication}
+ */
+export function BitbucketAdapter(config: BitbucketConfig) {
+  return Oauth2Adapter({
+    ...config,
+    type: "bitbucket",
+    endpoint: {
+      authorization: "https://bitbucket.org/site/oauth2/authorize",
+      token: "https://bitbucket.org/site/oauth2/access_token",
+    },
+  })
+}

--- a/packages/openauth/src/adapter/bitbucket.ts
+++ b/packages/openauth/src/adapter/bitbucket.ts
@@ -2,69 +2,45 @@ import { Oauth2Adapter, Oauth2WrappedConfig } from "./oauth2.js"
 
 /**
  * Represents the various scopes that can be used for Bitbucket API access.
- * 
+ *
  * A descriptor lacking the scopes element is implicitly assumed to require all scopes and as a result, Bitbucket will require end users authorizing/installing the add-on to explicitly accept all scopes.
- * 
- * - `project`: Read access to projects.
- * - `project:write`: Write access to projects.
- * - `project:admin`: Admin access to projects.
- * - `repository`: Read access to repositories.
- * - `repository:write`: Write access to repositories.
- * - `repository:admin`: Admin access to repositories.
- * - `repository:delete`: Delete access to repositories.
- * - `pullrequest`: Read access to pull requests.
- * - `pullrequest:write`: Write access to pull requests.
- * - `issue`: Read access to issues.
- * - `issue:write`: Write access to issues.
- * - `wiki`: Access to wikis.
- * - `webhook`: Access to webhooks.
- * - `snippet`: Read access to snippets.
- * - `snippet:write`: Write access to snippets.
- * - `email`: Access to email addresses.
- * - `account`: Read access to account information.
- * - `account:write`: Write access to account information.
- * - `pipeline`: Read access to pipelines.
- * - `pipeline:write`: Write access to pipelines.
- * - `pipeline:variable`: Access to pipeline variables.
- * - `runner`: Read access to runners.
- * - `runner:write`: Write access to runners.
- * 
+ *
  * @see {@link https://developer.atlassian.com/cloud/bitbucket/rest/intro/#authentication}
  */
-type Scope = 
-    | "project"
-    | "project:write"
-    | "project:admin"
-    | "repository"
-    | "repository:write"
-    | "repository:admin"
-    | "repository:delete"
-    | "pullrequest"
-    | "pullrequest:write"
-    | "issue"
-    | "issue:write"
-    | "wiki"
-    | "webhook"
-    | "snippet"
-    | "snippet:write"
-    | "email"
-    | "account"
-    | "account:write"
-    | "pipeline"
-    | "pipeline:write"
-    | "pipeline:variable"
-    | "runner"
-    | "runner:write"
+type Scope =
+  | "project"
+  | "project:write"
+  | "project:admin"
+  | "repository"
+  | "repository:write"
+  | "repository:admin"
+  | "repository:delete"
+  | "pullrequest"
+  | "pullrequest:write"
+  | "issue"
+  | "issue:write"
+  | "wiki"
+  | "webhook"
+  | "snippet"
+  | "snippet:write"
+  | "email"
+  | "account"
+  | "account:write"
+  | "pipeline"
+  | "pipeline:write"
+  | "pipeline:variable"
+  | "runner"
+  | "runner:write"
 
 /**
  * Configuration interface for Bitbucket OAuth2 integration.
- * 
+ *
  * @extends Oauth2WrappedConfig
- * 
+ *
  * @property {Scope[]} scopes - An array of scopes that specify the permissions requested from the user.
  */
 export interface BitbucketConfig extends Oauth2WrappedConfig {
-    scopes: Scope[]
+  scopes: Scope[]
 }
 
 /**
@@ -72,7 +48,7 @@ export interface BitbucketConfig extends Oauth2WrappedConfig {
  *
  * This function configures an OAuth2 adapter specifically for Bitbucket by
  * providing the necessary authorization and token endpoints.
- * 
+ *
  * @see {@link https://developer.atlassian.com/cloud/bitbucket/rest/intro/#authentication}
  */
 export function BitbucketAdapter(config: BitbucketConfig) {

--- a/packages/openauth/src/adapter/bitbucket.ts
+++ b/packages/openauth/src/adapter/bitbucket.ts
@@ -5,7 +5,7 @@ import { Oauth2Adapter, Oauth2WrappedConfig } from "./oauth2.js"
  *
  * A descriptor lacking the scopes element is implicitly assumed to require all scopes and as a result, Bitbucket will require end users authorizing/installing the add-on to explicitly accept all scopes.
  *
- * @see {@link https://developer.atlassian.com/cloud/bitbucket/rest/intro/#authentication}
+ * @see {@link https://developer.atlassian.com/cloud/bitbucket/rest/intro/#bitbucket-oauth-2-0-scopes}
  */
 type Scope =
   | "project"


### PR DESCRIPTION
## Bitbucket Adapter

- Integrated Bitbucket adapter using [Bitbucket's authentication documentation](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#authentication).
- There are many scopes that can be added. Refer to [Bitbucket OAuth 2.0 scopes](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#bitbucket-oauth-2-0-scopes) for the actual list of scopes supported by `oauth2`.
  - Keep in mind they do mention in the docs [OAuth 2.0 documentation](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#oauth-2-0) the following statement:  
    > Our OAuth 2 implementation is merged in with our existing OAuth 1 in such a way that existing OAuth 1 consumers automatically become valid OAuth 2 clients. The only thing you need to do is edit your existing consumer and configure a callback URL.  
   
    **Therefore, using the endpoints for `oauth2` should not affect anything.**
- Overrode the `scopes[]` to use a union for type safety. **Same as the SlackAdapter** ([GitHub Pull Request #101](https://github.com/openauthjs/openauth/pull/101)).