### PR TITLE
refactor: export `AuthorizationState` for better reusability

### DIFF
--- a/.changeset/few-boats-train.md
+++ b/.changeset/few-boats-train.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+refactor: export `AuthorizationState` for better reusability

--- a/packages/openauth/src/authorizer.ts
+++ b/packages/openauth/src/authorizer.ts
@@ -23,7 +23,7 @@ export interface OnSuccessResponder<
   ): Promise<Response>
 }
 
-interface AuthorizationState {
+export interface AuthorizationState {
   redirect_uri: string
   response_type: string
   state: string


### PR DESCRIPTION
Whenever you're trying to re-export the `authorizer` from the internal package, typescript throws the following error:

```
TS4023: Exported variable 'createAuthorizer' has or is using name 'AuthorizationState'
```

The following PR addresses this issue by exporting the necessary types.

Resolved #89