### PR TITLE
example: fix astro env types

### DIFF
--- a/examples/client/astro/src/env.d.ts
+++ b/examples/client/astro/src/env.d.ts
@@ -1,4 +1,4 @@
-import type { SubjectPayload } from "@openauthjs/openauth/session"
+import type { SubjectPayload } from "@openauthjs/openauth/subject"
 import { subjects } from "./auth"
 
 declare global {


### PR DESCRIPTION
`Astro.locals.subject` was resolving as any after the rename