### PR TITLE
Add PKCE option to Oauth2Provider

### DIFF
--- a/.changeset/chilled-sloths-drum.md
+++ b/.changeset/chilled-sloths-drum.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+Add PKCE option to Oauth2Provider

--- a/packages/openauth/src/provider/x.ts
+++ b/packages/openauth/src/provider/x.ts
@@ -41,5 +41,6 @@ export function XProvider(config: XProviderConfig) {
       authorization: "https://twitter.com/i/oauth2/authorize",
       token: "https://api.x.com/2/oauth2/token",
     },
+    pkce: true,
   })
 }


### PR DESCRIPTION
Closes https://github.com/openauthjs/openauth/issues/148

The x.com provider does not work out of the box because the x.com oauth2 does not work without PKCE. See the "Grant Types" section in https://developer.x.com/en/docs/authentication/oauth-2-0/authorization-code. This PR adds an option to the Oauth2Provider base function to include PKCE flow which fixes the x.com provider.