### PR TITLE
add ability to resend verification code during registration

### DIFF
--- a/.changeset/tiny-beds-cough.md
+++ b/.changeset/tiny-beds-cough.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+add ability to resend verification code during registration

--- a/packages/openauth/src/provider/password.ts
+++ b/packages/openauth/src/provider/password.ts
@@ -336,7 +336,18 @@ export function PasswordProvider(
             email,
           })
         }
-
+        
+        if (action === "register" && provider.type === "code") {
+          const code = generate()
+          await config.sendCode(provider.email, code)
+          return transition({
+           type: "code",
+           code,
+           password: provider.password,
+           email: provider.email,
+          })
+        }
+      
         if (action === "verify" && provider.type === "code") {
           const code = fd.get("code")?.toString()
           if (!code || !timingSafeCompare(code, provider.code))


### PR DESCRIPTION
Currently, the resend verification code functionality is only available during password changes or updates. However, during the registration process, users may encounter email delivery failures. This situation forces users to restart the entire registration process to obtain a new verification code, which can be frustrating and confusing.

This PR introduces the ability to resend the verification code during the registration process. When creating custom UI, developers can add a "Resend" button that submits a form to request a new verification code. This action reloads the page and sets the appropriate authentication state, allowing the registration process to resume with the new code.

## Example Implementation
Below is an example of how the resend functionality can be integrated into the registration process:

```html
<form method="post" class="flex gap-0.5 items-center justify-center m-0">
    <input type="hidden" name="action" value="register" />
    <span>Didn't receive the code? </span>
    <Button 
        variant="link" 
        class="p-0 h-0 underline focus-visible:ring-0" 
        data-component="resend" 
        disabled
    >
        Resend
    </Button>
</form>
```        

Maybe we can add this to the built-in themes.

For reference, you can review how the Change handler has been implemented in PasswordUI: [PasswordUI Change Handler](https://github.com/openauthjs/openauth/blob/master/packages/openauth/src/ui/password.tsx#L361)