### PR TITLE
Add use parameter to JWKs

### DIFF
--- a/.changeset/sharp-knives-guess.md
+++ b/.changeset/sharp-knives-guess.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+Add use: sig to jwks.

--- a/packages/openauth/src/keys.ts
+++ b/packages/openauth/src/keys.ts
@@ -71,6 +71,7 @@ export async function signingKeys(storage: StorageAdapter): Promise<KeyPair[]> {
     const privateKey = await importPKCS8(value.privateKey, value.alg)
     const jwk = await exportJWK(publicKey)
     jwk.kid = value.id
+    jwk.use = "sig"
     results.push({
       id: value.id,
       alg: signingAlg,


### PR DESCRIPTION
It's not necessary, but might be helpful in some cases to include `"use": "sig"` to the JWKs. See [RFC 7517 4.2](https://datatracker.ietf.org/doc/html/rfc7517?utm_source=chatgpt.com#section-4.2)

(I ran into some code that was looking for this)