### PR TITLE
fix: call validatePassword cb on password change

### DIFF
--- a/.changeset/early-weeks-tap.md
+++ b/.changeset/early-weeks-tap.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+Call password validation callback on password reset


### PR DESCRIPTION
As described in #182, the user-provided `validatePassword` callback of the `PasswordProvider` is only called when creating a new account but not when changing the password of an existing one.

This PR adds the logic to call the callback to that route.

fixes #182 