### PR TITLE
Fix providers `clientID` key case

### DIFF
--- a/.changeset/fix-client-id-key-case.md
+++ b/.changeset/fix-client-id-key-case.md
@@ -1,0 +1,5 @@
+---
+"@openauthjs/openauth": patch
+---
+
+Fix providers client id case from `clientId` to `clientID`

--- a/packages/openauth/src/provider/apple.ts
+++ b/packages/openauth/src/provider/apple.ts
@@ -9,7 +9,7 @@
  * export default issuer({
  *   providers: {
  *     apple: AppleProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -24,7 +24,7 @@
  * export default issuer({
  *   providers: {
  *     apple: AppleOidcProvider({
- *       clientId: "1234567890"
+ *       clientID: "1234567890"
  *     })
  *   }
  * })
@@ -46,7 +46,7 @@ export interface AppleOidcConfig extends OidcWrappedConfig {}
  * @example
  * ```ts
  * AppleProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```
@@ -71,7 +71,7 @@ export function AppleProvider(config: AppleConfig) {
  * @example
  * ```ts
  * AppleOidcProvider({
- *   clientId: "1234567890"
+ *   clientID: "1234567890"
  * })
  * ```
  */

--- a/packages/openauth/src/provider/cognito.ts
+++ b/packages/openauth/src/provider/cognito.ts
@@ -9,7 +9,7 @@
  *     cognito: CognitoProvider({
  *       domain: "your-domain.auth.us-east-1.amazoncognito.com",
  *       region: "us-east-1",
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -55,7 +55,7 @@ export interface CognitoConfig extends Oauth2WrappedConfig {
  * CognitoProvider({
  *   domain: "your-domain.auth.us-east-1.amazoncognito.com",
  *   region: "us-east-1",
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/discord.ts
+++ b/packages/openauth/src/provider/discord.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     discord: DiscordProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -28,7 +28,7 @@ export interface DiscordConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * DiscordProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/facebook.ts
+++ b/packages/openauth/src/provider/facebook.ts
@@ -9,7 +9,7 @@
  * export default issuer({
  *   providers: {
  *     facebook: FacebookProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -24,7 +24,7 @@
  * export default issuer({
  *   providers: {
  *     facebook: FacebookOidcProvider({
- *       clientId: "1234567890"
+ *       clientID: "1234567890"
  *     })
  *   }
  * })
@@ -46,7 +46,7 @@ export interface FacebookOidcConfig extends OidcWrappedConfig {}
  * @example
  * ```ts
  * FacebookProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```
@@ -71,7 +71,7 @@ export function FacebookProvider(config: FacebookConfig) {
  * @example
  * ```ts
  * FacebookOidcProvider({
- *   clientId: "1234567890"
+ *   clientID: "1234567890"
  * })
  * ```
  */

--- a/packages/openauth/src/provider/github.ts
+++ b/packages/openauth/src/provider/github.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     github: GithubProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -28,7 +28,7 @@ export interface GithubConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * GithubProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/google.ts
+++ b/packages/openauth/src/provider/google.ts
@@ -9,7 +9,7 @@
  * export default issuer({
  *   providers: {
  *     google: GoogleProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -24,7 +24,7 @@
  * export default issuer({
  *   providers: {
  *     google: GoogleOidcProvider({
- *       clientId: "1234567890"
+ *       clientID: "1234567890"
  *     })
  *   }
  * })
@@ -46,7 +46,7 @@ export interface GoogleOidcConfig extends OidcWrappedConfig {}
  * @example
  * ```ts
  * GoogleProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```
@@ -71,7 +71,7 @@ export function GoogleProvider(config: GoogleConfig) {
  * @example
  * ```ts
  * GoogleOidcProvider({
- *   clientId: "1234567890"
+ *   clientID: "1234567890"
  * })
  * ```
  */

--- a/packages/openauth/src/provider/jumpcloud.ts
+++ b/packages/openauth/src/provider/jumpcloud.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     jumpcloud: JumpCloudProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -28,7 +28,7 @@ export interface JumpCloudConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * JumpCloudProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/keycloak.ts
+++ b/packages/openauth/src/provider/keycloak.ts
@@ -9,7 +9,7 @@
  *     keycloak: KeycloakProvider({
  *       baseUrl: "https://your-keycloak-domain",
  *       realm: "your-realm",
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -58,7 +58,7 @@ export interface KeycloakConfig extends Oauth2WrappedConfig {
  * KeycloakProvider({
  *   baseUrl: "https://your-keycloak-domain",
  *   realm: "your-realm",
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/microsoft.ts
+++ b/packages/openauth/src/provider/microsoft.ts
@@ -10,7 +10,7 @@
  *   providers: {
  *     microsoft: MicrosoftProvider({
  *       tenant: "1234567890",
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -25,7 +25,7 @@
  * export default issuer({
  *   providers: {
  *     microsoft: MicrosoftOidcProvider({
- *       clientId: "1234567890"
+ *       clientID: "1234567890"
  *     })
  *   }
  * })
@@ -62,7 +62,7 @@ export interface MicrosoftOidcConfig extends OidcWrappedConfig {}
  * ```ts
  * MicrosoftProvider({
  *   tenant: "1234567890",
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```
@@ -87,7 +87,7 @@ export function MicrosoftProvider(config: MicrosoftConfig) {
  * @example
  * ```ts
  * MicrosoftOidcProvider({
- *   clientId: "1234567890"
+ *   clientID: "1234567890"
  * })
  * ```
  */

--- a/packages/openauth/src/provider/oauth2.ts
+++ b/packages/openauth/src/provider/oauth2.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     oauth2: Oauth2Provider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321",
  *       endpoint: {
  *         authorization: "https://auth.myserver.com/authorize",

--- a/packages/openauth/src/provider/oidc.ts
+++ b/packages/openauth/src/provider/oidc.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     oauth2: OidcProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       issuer: "https://auth.myserver.com"
  *     })
  *   }

--- a/packages/openauth/src/provider/slack.ts
+++ b/packages/openauth/src/provider/slack.ts
@@ -8,7 +8,7 @@
  *   providers: {
  *     slack: SlackProvider({
  *       team: "T1234567890",
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321",
  *       scopes: ["openid", "email", "profile"]
  *     })
@@ -49,7 +49,7 @@ export interface SlackConfig extends Oauth2WrappedConfig {
  * ```ts
  * SlackProvider({
  *   team: "T1234567890",
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321",
  *   scopes: ["openid", "email", "profile"]
  * })

--- a/packages/openauth/src/provider/spotify.ts
+++ b/packages/openauth/src/provider/spotify.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     spotify: SpotifyProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -28,7 +28,7 @@ export interface SpotifyConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * SpotifyProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/twitch.ts
+++ b/packages/openauth/src/provider/twitch.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     twitch: TwitchProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -28,7 +28,7 @@ export interface TwitchConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * TwitchProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/x.ts
+++ b/packages/openauth/src/provider/x.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     x: XProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -28,7 +28,7 @@ export interface XProviderConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * XProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/packages/openauth/src/provider/yahoo.ts
+++ b/packages/openauth/src/provider/yahoo.ts
@@ -7,7 +7,7 @@
  * export default issuer({
  *   providers: {
  *     yahoo: YahooProvider({
- *       clientId: "1234567890",
+ *       clientID: "1234567890",
  *       clientSecret: "0987654321"
  *     })
  *   }
@@ -28,7 +28,7 @@ export interface YahooConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * YahooProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```

--- a/www/src/content/docs/docs/provider/apple.mdx
+++ b/www/src/content/docs/docs/provider/apple.mdx
@@ -22,7 +22,7 @@ import { AppleProvider } from "@openauthjs/openauth/provider/apple"
 export default issuer({
   providers: {
     apple: AppleProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -37,7 +37,7 @@ import { AppleOidcProvider } from "@openauthjs/openauth/provider/apple"
 export default issuer({
   providers: {
     apple: AppleOidcProvider({
-      clientId: "1234567890"
+      clientID: "1234567890"
     })
   }
 })
@@ -65,7 +65,7 @@ Create an Apple OIDC provider.
 This is useful if you just want to verify the user's email address.
 ```ts
 AppleOidcProvider({
-  clientId: "1234567890"
+  clientID: "1234567890"
 })
 ```
 </Segment>
@@ -87,7 +87,7 @@ The config for the provider.
 Create an Apple OAuth2 provider.
 ```ts
 AppleProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/cognito.mdx
+++ b/www/src/content/docs/docs/provider/cognito.mdx
@@ -22,7 +22,7 @@ export default issuer({
     cognito: CognitoProvider({
       domain: "your-domain.auth.us-east-1.amazoncognito.com",
       region: "us-east-1",
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -51,7 +51,7 @@ Create a Cognito OAuth2 provider.
 CognitoProvider({
   domain: "your-domain.auth.us-east-1.amazoncognito.com",
   region: "us-east-1",
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/discord.mdx
+++ b/www/src/content/docs/docs/provider/discord.mdx
@@ -20,7 +20,7 @@ import { DiscordProvider } from "@openauthjs/openauth/provider/discord"
 export default issuer({
   providers: {
     discord: DiscordProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -47,7 +47,7 @@ The config for the provider.
 Create a Discord OAuth2 provider.
 ```ts
 DiscordProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/facebook.mdx
+++ b/www/src/content/docs/docs/provider/facebook.mdx
@@ -22,7 +22,7 @@ import { FacebookProvider } from "@openauthjs/openauth/provider/facebook"
 export default issuer({
   providers: {
     facebook: FacebookProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -37,7 +37,7 @@ import { FacebookOidcProvider } from "@openauthjs/openauth/provider/facebook"
 export default issuer({
   providers: {
     facebook: FacebookOidcProvider({
-      clientId: "1234567890"
+      clientID: "1234567890"
     })
   }
 })
@@ -65,7 +65,7 @@ Create a Facebook OIDC provider.
 This is useful if you just want to verify the user's email address.
 ```ts
 FacebookOidcProvider({
-  clientId: "1234567890"
+  clientID: "1234567890"
 })
 ```
 </Segment>
@@ -87,7 +87,7 @@ The config for the provider.
 Create a Facebook OAuth2 provider.
 ```ts
 FacebookProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/github.mdx
+++ b/www/src/content/docs/docs/provider/github.mdx
@@ -20,7 +20,7 @@ import { GithubProvider } from "@openauthjs/openauth/provider/github"
 export default issuer({
   providers: {
     github: GithubProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -47,7 +47,7 @@ The config for the provider.
 Create a Github OAuth2 provider.
 ```ts
 GithubProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/google.mdx
+++ b/www/src/content/docs/docs/provider/google.mdx
@@ -22,7 +22,7 @@ import { GoogleProvider } from "@openauthjs/openauth/provider/google"
 export default issuer({
   providers: {
     google: GoogleProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -37,7 +37,7 @@ import { GoogleOidcProvider } from "@openauthjs/openauth/provider/google"
 export default issuer({
   providers: {
     google: GoogleOidcProvider({
-      clientId: "1234567890"
+      clientID: "1234567890"
     })
   }
 })
@@ -65,7 +65,7 @@ Create a Google OIDC provider.
 This is useful if you just want to verify the user's email address.
 ```ts
 GoogleOidcProvider({
-  clientId: "1234567890"
+  clientID: "1234567890"
 })
 ```
 </Segment>
@@ -87,7 +87,7 @@ The config for the provider.
 Create a Google OAuth2 provider.
 ```ts
 GoogleProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/jumpcloud.mdx
+++ b/www/src/content/docs/docs/provider/jumpcloud.mdx
@@ -20,7 +20,7 @@ import { JumpCloudProvider } from "@openauthjs/openauth/provider/jumpcloud"
 export default issuer({
   providers: {
     jumpcloud: JumpCloudProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -47,7 +47,7 @@ The config for the provider.
 Create a JumpCloud OAuth2 provider.
 ```ts
 JumpCloudProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/keycloak.mdx
+++ b/www/src/content/docs/docs/provider/keycloak.mdx
@@ -22,7 +22,7 @@ export default issuer({
     keycloak: KeycloakProvider({
       baseUrl: "https://your-keycloak-domain",
       realm: "your-realm",
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -51,7 +51,7 @@ Create a Keycloak OAuth2 provider.
 KeycloakProvider({
   baseUrl: "https://your-keycloak-domain",
   realm: "your-realm",
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/microsoft.mdx
+++ b/www/src/content/docs/docs/provider/microsoft.mdx
@@ -23,7 +23,7 @@ export default issuer({
   providers: {
     microsoft: MicrosoftProvider({
       tenant: "1234567890",
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -38,7 +38,7 @@ import { MicrosoftOidcProvider } from "@openauthjs/openauth/provider/microsoft"
 export default issuer({
   providers: {
     microsoft: MicrosoftOidcProvider({
-      clientId: "1234567890"
+      clientID: "1234567890"
     })
   }
 })
@@ -66,7 +66,7 @@ Create a Microsoft OIDC provider.
 This is useful if you just want to verify the user's email address.
 ```ts
 MicrosoftOidcProvider({
-  clientId: "1234567890"
+  clientID: "1234567890"
 })
 ```
 </Segment>
@@ -89,7 +89,7 @@ Create a Microsoft OAuth2 provider.
 ```ts
 MicrosoftProvider({
   tenant: "1234567890",
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/oauth2.mdx
+++ b/www/src/content/docs/docs/provider/oauth2.mdx
@@ -20,7 +20,7 @@ import { Oauth2Provider } from "@openauthjs/openauth/provider/oauth2"
 export default issuer({
   providers: {
     oauth2: Oauth2Provider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321",
       endpoint: {
         authorization: "https://auth.myserver.com/authorize",

--- a/www/src/content/docs/docs/provider/oidc.mdx
+++ b/www/src/content/docs/docs/provider/oidc.mdx
@@ -20,7 +20,7 @@ import { OidcProvider } from "@openauthjs/openauth/provider/oidc"
 export default issuer({
   providers: {
     oauth2: OidcProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       issuer: "https://auth.myserver.com"
     })
   }

--- a/www/src/content/docs/docs/provider/slack.mdx
+++ b/www/src/content/docs/docs/provider/slack.mdx
@@ -21,7 +21,7 @@ export default issuer({
   providers: {
     slack: SlackProvider({
       team: "T1234567890",
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321",
       scopes: ["openid", "email", "profile"]
     })
@@ -50,7 +50,7 @@ Creates a [Slack OAuth2 provider](https://api.slack.com/authentication/sign-in-w
 ```ts
 SlackProvider({
   team: "T1234567890",
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321",
   scopes: ["openid", "email", "profile"]
 })

--- a/www/src/content/docs/docs/provider/spotify.mdx
+++ b/www/src/content/docs/docs/provider/spotify.mdx
@@ -20,7 +20,7 @@ import { SpotifyProvider } from "@openauthjs/openauth/provider/spotify"
 export default issuer({
   providers: {
     spotify: SpotifyProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -47,7 +47,7 @@ The config for the provider.
 Create a Spotify OAuth2 provider.
 ```ts
 SpotifyProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/twitch.mdx
+++ b/www/src/content/docs/docs/provider/twitch.mdx
@@ -20,7 +20,7 @@ import { TwitchProvider } from "@openauthjs/openauth/provider/twitch"
 export default issuer({
   providers: {
     twitch: TwitchProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -47,7 +47,7 @@ The config for the provider.
 Create a Twitch OAuth2 provider.
 ```ts
 TwitchProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/x.mdx
+++ b/www/src/content/docs/docs/provider/x.mdx
@@ -20,7 +20,7 @@ import { XProvider } from "@openauthjs/openauth/provider/x"
 export default issuer({
   providers: {
     x: XProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -47,7 +47,7 @@ The config for the provider.
 Create a X.com OAuth2 provider.
 ```ts
 XProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```

--- a/www/src/content/docs/docs/provider/yahoo.mdx
+++ b/www/src/content/docs/docs/provider/yahoo.mdx
@@ -20,7 +20,7 @@ import { YahooProvider } from "@openauthjs/openauth/provider/yahoo"
 export default issuer({
   providers: {
     yahoo: YahooProvider({
-      clientId: "1234567890",
+      clientID: "1234567890",
       clientSecret: "0987654321"
     })
   }
@@ -47,7 +47,7 @@ The config for the provider.
 Create a Yahoo OAuth2 provider.
 ```ts
 YahooProvider({
-  clientId: "1234567890",
+  clientID: "1234567890",
   clientSecret: "0987654321"
 })
 ```


### PR DESCRIPTION
This PR is fixing the case of provider 
client id key from `clientId` to `clientID`