### PR TITLE
docs: reflect that Next.js often uses a src directory

### DIFF
--- a/www/src/content/docs/docs/start/sst.mdx
+++ b/www/src/content/docs/docs/start/sst.mdx
@@ -47,6 +47,11 @@ Select the defaults and pick **AWS**. This'll create a `sst.config.ts` file in y
 
 Next, let's add a directory for our OpenAuth server.
 
+If you're using the src directory in Next.js, place the auth folder inside of it:
+```bash
+mkdir src/auth
+```
+Otherwise, create it at the root of your project:
 ```bash
 mkdir auth
 ```

--- a/www/src/content/docs/docs/start/standalone.mdx
+++ b/www/src/content/docs/docs/start/standalone.mdx
@@ -38,6 +38,11 @@ This will start our Next.js app at `http://localhost:3000`.
 
 Next, let's add a directory for our OpenAuth server.
 
+If you're using the src directory in Next.js, place the auth folder inside of it:
+```bash
+mkdir src/auth
+```
+Otherwise, create it at the root of your project:
 ```bash
 mkdir auth
 ```


### PR DESCRIPTION
I added a clarification to both quickstarts (Standalone & SST) specifying that if a Next.js project uses the src directory, the auth folder should be placed inside of it (src/auth). This ensures consistency with Next.js conventions and avoids confusion for developers structuring their projects.