### PR TITLE
docs: update GitHubProvider clientID param casing

### DIFF
--- a/packages/openauth/src/provider/github.ts
+++ b/packages/openauth/src/provider/github.ts
@@ -28,7 +28,7 @@ export interface GithubConfig extends Oauth2WrappedConfig {}
  * @example
  * ```ts
  * GithubProvider({
- *   clientId: "1234567890",
+ *   clientID: "1234567890",
  *   clientSecret: "0987654321"
  * })
  * ```


### PR DESCRIPTION
Noticed this while setting up the provider for the first time.

P.S. thanks for the amazing library! 