### PR TITLE
feat(apple-oidc): support iOS AuthenticationServices Sign In with Apple flow

### DIFF
--- a/packages/openauth/src/provider/apple.ts
+++ b/packages/openauth/src/provider/apple.ts
@@ -71,7 +71,8 @@ export function AppleProvider(config: AppleConfig) {
  * @example
  * ```ts
  * AppleOidcProvider({
- *   clientID: "1234567890"
+ *   clientID: "1234567890",
+ *   clientSecret: "your-client-secret" // Required for Apple OIDC
  * })
  * ```
  */
@@ -80,5 +81,7 @@ export function AppleOidcProvider(config: AppleOidcConfig) {
     ...config,
     type: "apple" as const,
     issuer: "https://appleid.apple.com",
+    responseType: "code",
+    tokenEndpointAuthMethod: "client_secret_post",
   })
 }

--- a/packages/openauth/src/provider/apple.ts
+++ b/packages/openauth/src/provider/apple.ts
@@ -35,6 +35,8 @@
 
 import { Oauth2Provider, Oauth2WrappedConfig } from "./oauth2.js"
 import { OidcProvider, OidcWrappedConfig } from "./oidc.js"
+import { createRemoteJWKSet, jwtVerify } from "jose"
+import { OauthError } from "../error.js"
 
 export interface AppleConfig extends Oauth2WrappedConfig {}
 export interface AppleOidcConfig extends OidcWrappedConfig {}
@@ -66,6 +68,7 @@ export function AppleProvider(config: AppleConfig) {
  * Create an Apple OIDC provider.
  *
  * This is useful if you just want to verify the user's email address.
+ * Includes support for client_credentials flow using Apple ID Token.
  *
  * @param config - The config for the provider.
  * @example
@@ -77,11 +80,64 @@ export function AppleProvider(config: AppleConfig) {
  * ```
  */
 export function AppleOidcProvider(config: AppleOidcConfig) {
-  return OidcProvider({
+  const baseProvider = OidcProvider({
     ...config,
     type: "apple" as const,
     issuer: "https://appleid.apple.com",
     responseType: "code",
     tokenEndpointAuthMethod: "client_secret_post",
   })
+
+  baseProvider.client = async ({ clientID, params }) => {
+    if (clientID !== config.clientID) {
+      throw new OauthError("unauthorized_client", "Client ID mismatch.")
+    }
+    if (!config.clientSecret) {
+      throw new OauthError("server_error", "Provider configuration missing clientSecret.")
+    }
+
+    const idToken = params.id_token
+    const appId = params.app_id
+
+    if (!idToken) {
+      throw new OauthError("invalid_request", "Missing required parameter: id_token")
+    }
+    if (!appId) {
+      throw new OauthError("invalid_request", "Missing required parameter: app_id")
+    }
+
+    try {
+      const jwksUrl = new URL(`https://appleid.apple.com/auth/keys`) as any
+      const jwks = createRemoteJWKSet(jwksUrl)
+
+      const { payload } = await jwtVerify(idToken, jwks, {
+        issuer: "https://appleid.apple.com",
+        audience: appId,
+      })
+
+      const email = payload.email as string
+      const isEmailVerified = payload.email_verified === true || String(payload.email_verified) === 'true'
+
+      if (!email) {
+        throw new OauthError("invalid_grant", "Email not found in Apple ID token. User might have used private relay without granting email access.")
+      }
+      if (!isEmailVerified) {
+        console.warn(`Apple email (${email}) is not verified. Proceeding, but verification recommended.`)
+      }
+
+      return {
+        id: {
+          email: email,
+          email_verified: isEmailVerified,
+          sub: payload.sub,
+        },
+        clientID: clientID
+      }
+
+    } catch (error: any) {
+      throw new OauthError("server_error", "Apple ID token verification failed.")
+    }
+  }
+
+  return baseProvider
 }

--- a/packages/openauth/src/provider/oidc.ts
+++ b/packages/openauth/src/provider/oidc.ts
@@ -77,6 +77,42 @@ export interface OidcConfig {
    * ```
    */
   query?: Record<string, string>
+  /**
+   * The response type to use for the OIDC flow.
+   * Use "id_token" for implicit flow or "code" for authorization code flow.
+   * Defaults to "id_token".
+   * 
+   * @example
+   * ```ts
+   * {
+   *   responseType: "code"
+   * }
+   * ```
+   */
+  responseType?: "id_token" | "code"
+  /**
+   * The client secret, required for authorization code flow.
+   * 
+   * @example
+   * ```ts
+   * {
+   *   clientSecret: "your-client-secret"
+   * }
+   * ```
+   */
+  clientSecret?: string
+  /**
+   * The token endpoint authentication method.
+   * Defaults to "client_secret_post".
+   * 
+   * @example
+   * ```ts
+   * {
+   *   tokenEndpointAuthMethod: "client_secret_basic"
+   * }
+   * ```
+   */
+  tokenEndpointAuthMethod?: "client_secret_post" | "client_secret_basic"
 }
 
 /**
@@ -99,11 +135,28 @@ export interface IdTokenResponse {
   raw: Record<string, any>
 }
 
+interface TokenResponse {
+  id_token: string
+  access_token?: string
+  token_type?: string
+  expires_in?: number
+  refresh_token?: string
+  [key: string]: unknown
+}
+
+interface ErrorResponse {
+  error?: string
+  error_description?: string
+  [key: string]: unknown
+}
+
 export function OidcProvider(
   config: OidcConfig,
 ): Provider<{ id: JWTPayload; clientID: string }> {
   const query = config.query || {}
   const scopes = config.scopes || []
+  const responseType = config.responseType || "id_token"
+  const tokenEndpointAuthMethod = config.tokenEndpointAuthMethod || "client_secret_post"
 
   const wk = lazy(() =>
     fetch(config.issuer + "/.well-known/openid-configuration").then(
@@ -138,7 +191,7 @@ export function OidcProvider(
           await wk().then((r) => r.authorization_endpoint),
         )
         authorization.searchParams.set("client_id", config.clientID)
-        authorization.searchParams.set("response_type", "id_token")
+        authorization.searchParams.set("response_type", responseType)
         authorization.searchParams.set("response_mode", "form_post")
         authorization.searchParams.set("state", provider.state)
         authorization.searchParams.set("nonce", provider.nonce)
@@ -160,14 +213,92 @@ export function OidcProvider(
             error.toString() as any,
             body.get("error_description")?.toString() || "",
           )
+        
+        // handle authorization code flow
+        const code = body.get("code")
+        if (code) {
+          if (!config.clientSecret) {
+            throw new OauthError(
+              "invalid_request" as const,
+              "Client secret is required for code flow"
+            )
+          }
+          
+          const tokenEndpoint = await wk().then((r) => r.token_endpoint)
+          const formData = new URLSearchParams()
+          formData.append("grant_type", "authorization_code")
+          formData.append("code", code.toString())
+          formData.append("redirect_uri", provider.redirect)
+
+          const headers: Record<string, string> = {
+            "Content-Type": "application/x-www-form-urlencoded",
+          }
+
+          if (tokenEndpointAuthMethod === "client_secret_post") {
+            formData.append("client_id", config.clientID)
+            formData.append("client_secret", config.clientSecret)
+          } else if (tokenEndpointAuthMethod === "client_secret_basic") {
+            const credentials = btoa(`${config.clientID}:${config.clientSecret}`)
+            headers["Authorization"] = `Basic ${credentials}`
+          }
+
+          const response = await fetch(tokenEndpoint, {
+            method: "POST",
+            headers,
+            body: formData,
+          })
+
+          if (!response.ok) {
+            const errorData = await response.json() as ErrorResponse
+            throw new OauthError(
+              (errorData.error as any) || "server_error",
+              errorData.error_description || "Failed to exchange code for token"
+            )
+          }
+
+          const tokenResponse = await response.json() as TokenResponse
+          const idToken = tokenResponse.id_token
+
+          if (!idToken) {
+            throw new OauthError(
+              "invalid_request" as const,
+              "Missing id_token in token response"
+            )
+          }
+
+          const result = await jwtVerify(idToken, await jwks(), {
+            audience: config.clientID,
+          })
+          
+          if (result.payload.nonce !== provider.nonce) {
+            throw new OauthError(
+              "invalid_request" as const,
+              "Invalid nonce"
+            )
+          }
+          
+          return ctx.success(c, {
+            id: result.payload,
+            clientID: config.clientID,
+          })
+        }
+
+        // handle implicit flow
         const idToken = body.get("id_token")
-        if (!idToken)
-          throw new OauthError("invalid_request", "Missing id_token")
+        if (!idToken) {
+          throw new OauthError(
+            "invalid_request" as const,
+            "Missing id_token or code"
+          )
+        }
         const result = await jwtVerify(idToken.toString(), await jwks(), {
           audience: config.clientID,
         })
         if (result.payload.nonce !== provider.nonce) {
-          throw new OauthError("invalid_request", "Invalid nonce")
+          throw new OauthError(
+            "invalid_request" as const,
+            "Invalid nonce"
+          )
         }
         return ctx.success(c, {
           id: result.payload,

--- a/packages/openauth/src/provider/provider.ts
+++ b/packages/openauth/src/provider/provider.ts
@@ -8,7 +8,7 @@ export interface Provider<Properties = any> {
   init: (route: ProviderRoute, options: ProviderOptions<Properties>) => void
   client?: (input: {
     clientID: string
-    clientSecret: string
+    clientSecret?: string,
     params: Record<string, string>
   }) => Promise<Properties>
 }


### PR DESCRIPTION
branched from #246 which fixed issues in Apple OIDC provider

resolves #210 

adds support for direct integration with iOS/macOS [AuthenticationServices](https://developer.apple.com/documentation/authenticationservices/implementing-user-authentication-with-sign-in-with-apple) (Sign in with Apple) by updating the AppleOidcProvider to validate Apple ID tokens via the client_credentials grant type.

Previously, OpenAuth had no way to directly validate Apple ID tokens obtained from iOS apps using the native Sign in with Apple flow. This required app developers to either:
1. Implement a separate authentication service for iOS
2. Use a custom web view that disrupted the native iOS experience
3. Send tokens to a custom backend for validation


This PR extends the OpenAuth client_credentials grant type to handle Apple ID token verification, allowing iOS applications to authenticate directly with the OpenAuth server:
1. The iOS app obtains an ID token through Apple's ASAuthorizationAppleIDProvider
2. The app sends this token to OpenAuth's /token endpoint via client_credentials grant
3. OpenAuth validates the token against Apple's JWKS and returns OpenAuth access/refresh tokens
4. The iOS app uses these tokens like any other OpenAuth client
