### PR TITLE
Documentation change: Update password.tsx to reference correct function

### DIFF
--- a/packages/openauth/src/ui/password.tsx
+++ b/packages/openauth/src/ui/password.tsx
@@ -7,7 +7,7 @@
  *
  * export default issuer({
  *   providers: {
- *     password: PasswordAdapter(
+ *     password: PasswordProvider(
  *       PasswordUI({
  *         copy: {
  *           error_email_taken: "This email is already taken."


### PR DESCRIPTION
```tsx
// Reference doc for the `PasswordUI`.
// https://openauth.js.org/docs/ui/password/
import { PasswordUI } from "@openauthjs/openauth/ui/password"
import { PasswordProvider } from "@openauthjs/openauth/provider/password"

export default issuer({
  providers: {
    password: PasswordAdapter( // <-- Replaces with Password provider per the above import
      PasswordUI({
        copy: {
          error_email_taken: "This email is already taken."
        },
        sendCode: (email, code) => console.log(email, code)
      })
    )
  },
  // ...
})
```

PasswordAdapter doesn't exist.

PasswordProvider docs have the same snippet but correct.

```tsx
// PasswordProvider docs
// https://openauth.js.org/docs/provider/password/
import { PasswordUI } from "@openauthjs/openauth/ui/password"
import { PasswordProvider } from "@openauthjs/openauth/provider/password"

export default issuer({
  providers: {
    password: PasswordProvider( <--
      PasswordUI({
        copy: {
          error_email_taken: "This email is already taken."
        },
        sendCode: (email, code) => console.log(email, code)
      })
    )
  },
  // ...
})
```