### PR TITLE
docs: Fix sample code workspaceID

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ const app = issuer({
     }
     return ctx.subject("user", {
       userID,
-      'a workspace id'
+      workspaceID: 'a workspace id'
     })
   }
 })

--- a/www/src/content/docs/docs/index.mdx
+++ b/www/src/content/docs/docs/index.mdx
@@ -179,7 +179,7 @@ const app = issuer({
     }
     return ctx.subject("user", {
       userID,
-      'a workspace id'
+      workspaceID: 'a workspace id'
     })
   }
 })


### PR DESCRIPTION
The readme has some invalid JS syntax (I'm pretty sure)