### PR TITLE
Add registration/access control to PasswordProvider and CodeProvider

### DIFF
--- a/packages/openauth/src/ui/password.tsx
+++ b/packages/openauth/src/ui/password.tsx
@@ -60,6 +60,10 @@ const DEFAULT_COPY = {
    */
   error_validation_error: "Password does not meet requirements.",
   /**
+   * Error message when registration is not allowed.
+   */
+  error_registration_not_allowed: "Registration is not allowed.",
+  /**
    * Title of the register page.
    */
   register_title: "Welcome to the app",
@@ -128,6 +132,14 @@ const DEFAULT_COPY = {
    * Copy for the continue button.
    */
   button_continue: "Continue",
+  /**
+   * Copy for the first-time login message.
+   */
+  first_time_prompt: "First time logging in?",
+  /**
+   * Copy for the reset password link for first-time users.
+   */
+  first_time_reset: "Reset your password",
 } satisfies {
   [key in `error_${
     | PasswordLoginError["type"]
@@ -141,7 +153,10 @@ type PasswordUICopy = typeof DEFAULT_COPY
  * Configure the password UI.
  */
 export interface PasswordUIOptions
-  extends Pick<PasswordConfig, "sendCode" | "validatePassword"> {
+  extends Pick<
+    PasswordConfig,
+    "sendCode" | "validatePassword" | "allowRegistration" | "userExists"
+  > {
   /**
    * Custom copy for the UI.
    */
@@ -160,6 +175,8 @@ export function PasswordUI(input: PasswordUIOptions): PasswordConfig {
   return {
     validatePassword: input.validatePassword,
     sendCode: input.sendCode,
+    allowRegistration: input.allowRegistration,
+    userExists: input.userExists,
     login: async (_req, form, error): Promise<Response> => {
       const jsx = (
         <Layout>
@@ -185,16 +202,28 @@ export function PasswordUI(input: PasswordUIOptions): PasswordConfig {
             />
             <button data-component="button">{copy.button_continue}</button>
             <div data-component="form-footer">
-              <span>
-                {copy.register_prompt}{" "}
-                <a data-component="link" href="register">
-                  {copy.register}
-                </a>
-              </span>
+              {input.allowRegistration !== false && (
+                <span>
+                  {copy.register_prompt}{" "}
+                  <a data-component="link" href="register">
+                    {copy.register}
+                  </a>
+                </span>
+              )}
               <a data-component="link" href="change">
                 {copy.change_prompt}
               </a>
             </div>
+            {input.allowRegistration === false && input.userExists && (
+              <div data-component="form-footer">
+                <span>
+                  {copy.first_time_prompt}{" "}
+                  <a data-component="link" href="change">
+                    {copy.first_time_reset}
+                  </a>
+                </span>
+              </div>
+            )}
           </form>
         </Layout>
       )


### PR DESCRIPTION
### Summary

Fix #199 

This PR adds flexible registration control to the PasswordProvider, enabling scenarios where sign-ups are restricted or completely disabled while supporting admin-created users through external system.

### New Configuration Options

`allowRegistration` - Controls whether new user registration is allowed:
- boolean: `true` (default) allows user registration, `false` disables user registration
- function: `(email: string) => boolean | Promise<boolean>` for custom validation logic (e.g., domain restrictions)

`userExists` - Callback to check if a user exists in an external system:
- `(email: string) => boolean | Promise<boolean>`
- Used during password reset flow to validate existing users when registration is disabled
- Only invoked when `allowRegistration === false`

### Implementation Details

#### Registration Flow Changes

- When `allowRegistration: false`: Registration routes redirect to login page
- When `allowRegistration: function`: Function validates each registration attempt on form submission
- UI updates: Registration links conditionally hidden when disabled

#### Password Reset Flow for Admin-Created Users

First-time log in when registration is disabled is handled with the existing password reset flow (new users need to reset their password before being able to log in).
At the password update step, if the user if not found in `Storage` and the user exists in external system, it is created in `Storage` and the regular reset logic continues.

### Examples

#### Admin-Created User First Login

1. Admin creates user "john@company.com" in external system (no OpenAuth storage entry)
2. User visits login page, sees "First time logging in? Reset your password" link
3. User clicks reset link, enters email, receives verification code
4. User enters code, proceeds to password setting screen
5. When user sets password:
   - OpenAuth checks storage → user not found
   - OpenAuth calls userExists("john@company.com") → returns true
   - OpenAuth creates storage entry for user
   - User completes password setup successfully
6. Future logins work normally

#### Domain-Restricted Registration

```ts
PasswordProvider(PasswordUI({
  allowRegistration: (email) => {
    return email.endsWith("@company.com") || email.endsWith("@contractor.com")
  },
  sendCode: sendEmailCode
}))
```

#### Disabled Registration with External Users

```ts
PasswordProvider(PasswordUI({
  allowRegistration: false,
  userExists: async (email) => {
    return await corporateDirectory.userExists(email)
  },
  sendCode: sendEmailCode
}))
```

### Breaking Changes

There shouldn't be.