### PR TITLE
Add createSubjects import to code example

### DIFF
--- a/www/src/content/docs/docs/index.mdx
+++ b/www/src/content/docs/docs/index.mdx
@@ -136,6 +136,7 @@ const app = issuer({
 Next up is the `subjects` field. Subjects are what the access token generated at the end of the auth flow will map to. Under the hood, the access token is a JWT that contains this data. You will likely just have a single subject to start but you can define additional ones for different types of users.
 
 ```ts title="subjects.ts"
+import { createSubjects } from "@openauthjs/openauth/subject"
 import { object, string } from "valibot"
 
 const subjects = createSubjects({


### PR DESCRIPTION
For some reason Cursor IDE intellisense did not show createSubjects from '@openauthjs/openauth/subject' when importing and the only option was '@openauthjs/openauth' which is marked as deprecated. So I thought it would be helpful if import line was present in the code snippet to prevent this

Cursor Version: 1.1.6
VSCode Version: 1.96.2