### PR TITLE
fix(issuer): ensure implicit flow complies with RFC 6749 Section 4.2.2

### DIFF
--- a/packages/openauth/src/issuer.ts
+++ b/packages/openauth/src/issuer.ts
@@ -525,19 +525,26 @@ export function issuer<
             )
             if (authorization.response_type === "token") {
               const location = new URL(authorization.redirect_uri)
-              const tokens = await generateTokens(ctx, {
-                subject,
-                type: type as string,
-                properties,
-                clientID: authorization.client_id,
-                ttl: {
-                  access: subjectOpts?.ttl?.access ?? ttlAccess,
-                  refresh: subjectOpts?.ttl?.refresh ?? ttlRefresh,
+              const tokens = await generateTokens(
+                ctx,
+                {
+                  subject,
+                  type: type as string,
+                  properties,
+                  clientID: authorization.client_id,
+                  ttl: {
+                    access: subjectOpts?.ttl?.access ?? ttlAccess,
+                    refresh: subjectOpts?.ttl?.refresh ?? ttlRefresh,
+                  },
                 },
-              })
+                {
+                  generateRefreshToken: false,
+                },
+              )
               location.hash = new URLSearchParams({
                 access_token: tokens.access,
-                refresh_token: tokens.refresh,
+                token_type: "Bearer",
+                expires_in: tokens.expiresIn.toString(),
                 state: authorization.state || "",
               }).toString()
               await auth.unset(ctx, "authorization")

--- a/packages/openauth/test/issuer.test.ts
+++ b/packages/openauth/test/issuer.test.ts
@@ -71,6 +71,45 @@ afterEach(() => {
   setSystemTime()
 })
 
+describe("implicit flow", () => {
+  test("success without refresh token", async () => {
+    const url = new URL("https://auth.example.com/authorize")
+    url.searchParams.set("client_id", "123")
+    url.searchParams.set("redirect_uri", "https://client.example.com/callback")
+    url.searchParams.set("response_type", "token")
+    url.searchParams.set("provider", "dummy")
+
+    let response = await auth.request(url.toString())
+    expect(response.status).toBe(302)
+
+    response = await auth.request(response.headers.get("location")!, {
+      headers: {
+        cookie: response.headers.get("set-cookie")!,
+      },
+    })
+
+    expect(response.status).toBe(302)
+    const location = new URL(response.headers.get("location")!)
+    expect(location.origin + location.pathname).toBe(
+      "https://client.example.com/callback",
+    )
+
+    const fragmentParams = new URLSearchParams(location.hash.substring(1))
+
+    expect(fragmentParams.has("access_token")).toBe(true)
+    expect(fragmentParams.get("access_token")).toMatch(/.+/)
+
+    expect(fragmentParams.get("token_type")).toBe("Bearer")
+
+    expect(fragmentParams.has("expires_in")).toBe(true)
+    expect(parseInt(fragmentParams.get("expires_in")!)).toBeGreaterThan(0)
+
+    expect(fragmentParams.has("refresh_token")).toBe(false)
+
+    expect(fragmentParams.has("state")).toBe(true)
+  })
+})
+
 describe("code flow", () => {
   test("success", async () => {
     const client = createClient({


### PR DESCRIPTION
- Remove refresh_token from implicit flow response (MUST NOT be issued per RFC 6749 § 4.2.2)
- Add required token_type parameter set to "Bearer" (REQUIRED per RFC 6749 § 4.2.2)
- Add expires_in parameter to response (RECOMMENDED per RFC 6749 § 4.2.2)
- Add test coverage verifying RFC 6749 compliance

Per RFC 6749 Section 4.2.2 (https://tools.ietf.org/html/rfc6749#section-4.2.2):
"The authorization server MUST NOT issue a refresh token"