### PR TITLE
Propagate `sendCode` typescript definition from Code UI to Code Provider

### DIFF
--- a/packages/openauth/src/ui/code.tsx
+++ b/packages/openauth/src/ui/code.tsx
@@ -24,7 +24,7 @@
  */
 /** @jsxImportSource hono/jsx */
 
-import { CodeProviderOptions } from "../provider/code.js"
+import { CodeProviderOptions, CodeProviderError } from "../provider/code.js"
 import { UnknownStateError } from "../error.js"
 import { Layout } from "./base.js"
 import { FormAlert } from "./form.js"
@@ -91,7 +91,7 @@ export interface CodeUIOptions {
    * }
    * ```
    */
-  sendCode: (claims: Record<string, string>, code: string) => Promise<void>
+  sendCode: (claims: Record<string, string>, code: string) => Promise<void | CodeProviderError>
   /**
    * Custom copy for the UI.
    */


### PR DESCRIPTION
This is a quick fix to propagate the correct typescript definition, defined in CodeProviderOptions, to CodeUIOptions.

I would like to make a check during `sendCode` execution to check if the user is registered within our system. In order to do that, I tried returning  `CodeProviderError` object from `sendCode` as defined in CodeProviderOptions, but I got a typescript error even though my implementation actually worked.

Upon further investigation, it seems that the two definitions of `sendCode` within CodeUI and CodeProvider are different.
Since the `sendCode` method is passed from CodeUI to CodeProvider, the two typescript definitions for the same method should match.

An alternative to this approach, and likely better, would be to update `CodeUIOptions.sendCode` definition to be the same as `CodeProviderOptions["sendCode"]` 