### PR TITLE
Change hidden input action from 'request' to 'resend'

### DIFF
--- a/packages/openauth/src/ui/code.tsx
+++ b/packages/openauth/src/ui/code.tsx
@@ -189,7 +189,7 @@ export function CodeUI(props: CodeUIOptions): CodeProviderOptions {
                   className="hidden"
                 />
               ))}
-              <input type="hidden" name="action" value="request" />
+              <input type="hidden" name="action" value="resend" />
               <div data-component="form-footer">
                 <span>
                   {copy.code_didnt_get}{" "}


### PR DESCRIPTION
This seems like it was meant to always be 'resend'. This PR fixes that so the UI updates to 'Code resent to <email>'.