### PR TITLE
fix(issuer): add token_type to authorization code flow token responses

### DIFF
--- a/packages/openauth/src/issuer.ts
+++ b/packages/openauth/src/issuer.ts
@@ -881,6 +881,7 @@ export function issuer<
         await Storage.remove(storage, key)
         return c.json({
           access_token: tokens.access,
+          token_type: "Bearer",
           expires_in: tokens.expiresIn,
           refresh_token: tokens.refresh,
         })
@@ -949,6 +950,7 @@ export function issuer<
         })
         return c.json({
           access_token: tokens.access,
+          token_type: "Bearer",
           refresh_token: tokens.refresh,
           expires_in: tokens.expiresIn,
         })

--- a/packages/openauth/test/issuer.test.ts
+++ b/packages/openauth/test/issuer.test.ts
@@ -221,6 +221,7 @@ describe("refresh token", () => {
     const refreshed = await response.json()
     expect(refreshed).toStrictEqual({
       access_token: expectNonEmptyString,
+      token_type: "Bearer",
       refresh_token: expectNonEmptyString,
       expires_in: expect.any(Number),
     })
@@ -247,6 +248,7 @@ describe("refresh token", () => {
     const refreshed = await response.json()
     expect(refreshed).toStrictEqual({
       access_token: expectNonEmptyString,
+      token_type: "Bearer",
       refresh_token: expectNonEmptyString,
       expires_in: expect.any(Number),
     })


### PR DESCRIPTION
Add `token_type: 'Bearer'` to token endpoint responses for both authorization_code and refresh_token grant types to comply with RFC 6749 Section 5.1.

## Changes
- Add `token_type: "Bearer"` to authorization_code grant response (line 883)
- Add `token_type: "Bearer"` to refresh_token grant response (line 951)
- Update tests to verify `token_type` is present in refresh token responses

## RFC Compliance
Per RFC 6749 Section 5.1 (https://tools.ietf.org/html/rfc6749#section-5.1):
> "The authorization server MUST include the token_type parameter in the response."

This ensures compatibility with OAuth 2.0 clients that require the `token_type` parameter, such as MCP clients using `@mastra/mcp`.

Related: PR #304 fixes the same issue for the implicit flow (response_type="token"). This PR addresses the authorization code flow.