### PR TITLE
fix(examples): prevent unnecessary IdP redirect when session is still valid

### DIFF
--- a/examples/client/nextjs/app/actions.ts
+++ b/examples/client/nextjs/app/actions.ts
@@ -36,8 +36,10 @@ export async function login() {
     const verified = await client.verify(subjects, accessToken.value, {
       refresh: refreshToken?.value,
     })
-    if (!verified.err && verified.tokens) {
-      await setTokens(verified.tokens.access, verified.tokens.refresh)
+    if (!verified.err) {
+      if (verified.tokens) {
+        await setTokens(verified.tokens.access, verified.tokens.refresh)
+      }
       redirect("/")
     }
   }

--- a/examples/quickstart/sst/app/actions.ts
+++ b/examples/quickstart/sst/app/actions.ts
@@ -37,8 +37,10 @@ export async function login() {
     const verified = await client.verify(subjects, accessToken.value, {
       refresh: refreshToken?.value,
     })
-    if (!verified.err && verified.tokens) {
-      await setTokens(verified.tokens.access, verified.tokens.refresh)
+    if (!verified.err) {
+      if (verified.tokens) {
+        await setTokens(verified.tokens.access, verified.tokens.refresh)
+      }
       redirect("/")
     }
   }

--- a/examples/quickstart/standalone/app/actions.ts
+++ b/examples/quickstart/standalone/app/actions.ts
@@ -37,8 +37,10 @@ export async function login() {
     const verified = await client.verify(subjects, accessToken.value, {
       refresh: refreshToken?.value,
     })
-    if (!verified.err && verified.tokens) {
-      await setTokens(verified.tokens.access, verified.tokens.refresh)
+    if (!verified.err) {
+      if (verified.tokens) {
+        await setTokens(verified.tokens.access, verified.tokens.refresh)
+      }
       redirect("/")
     }
   }

--- a/www/src/content/docs/docs/start/sst.mdx
+++ b/www/src/content/docs/docs/start/sst.mdx
@@ -240,8 +240,10 @@ export async function login() {
     const verified = await client.verify(subjects, accessToken.value, {
       refresh: refreshToken?.value,
     })
-    if (!verified.err && verified.tokens) {
-      await setTokens(verified.tokens.access, verified.tokens.refresh)
+    if (!verified.err) {
+      if (verified.tokens) {
+        await setTokens(verified.tokens.access, verified.tokens.refresh)
+      }
       redirect("/")
     }
   }

--- a/www/src/content/docs/docs/start/standalone.mdx
+++ b/www/src/content/docs/docs/start/standalone.mdx
@@ -201,8 +201,10 @@ export async function login() {
     const verified = await client.verify(subjects, accessToken.value, {
       refresh: refreshToken?.value,
     })
-    if (!verified.err && verified.tokens) {
-      await setTokens(verified.tokens.access, verified.tokens.refresh)
+    if (!verified.err) {
+      if (verified.tokens) {
+        await setTokens(verified.tokens.access, verified.tokens.refresh)
+      }
       redirect("/")
     }
   }


### PR DESCRIPTION
## Summary

The `login()` function in the examples checks for an existing valid session before redirecting to the IdP. However, `client.verify()` only populates `verified.tokens` when a token refresh actually occurs — when the access token is still valid, `tokens` is `undefined`. The original condition `!verified.err && verified.tokens` evaluates to `false` for valid (non-expired) sessions, causing the code to fall through to `client.authorize()` and trigger an unnecessary full OAuth round-trip.

The fix checks `!verified.err` alone to determine session validity, and only calls `setTokens` when `verified.tokens` is present (i.e., a refresh occurred).

## Files changed

- `examples/quickstart/sst/app/actions.ts`
- `examples/quickstart/standalone/app/actions.ts`
- `examples/client/nextjs/app/actions.ts`
- `www/src/content/docs/docs/start/sst.mdx`
- `www/src/content/docs/docs/start/standalone.mdx`

Note: the `auth()` function in those same files already handled this correctly with separate checks. The bug only affected `login()`.
